### PR TITLE
Fix translation_path() for multiple <lang>

### DIFF
--- a/lib/strava/l10n/tx_config.rb
+++ b/lib/strava/l10n/tx_config.rb
@@ -25,6 +25,7 @@ module Strava
         lang_map.split(',').each do |m|
           key_value = m.split(':', 2)
           result[key_value[0].strip] = key_value[1].strip
+          result
         end
       end
 

--- a/lib/strava/l10n/tx_resource.rb
+++ b/lib/strava/l10n/tx_resource.rb
@@ -50,7 +50,7 @@ module Strava
 
       def translation_path(language)
         path = String.new(@translation_file)
-        path['<lang>'] = language
+        path.gsub! '<lang>', language
         path
       end
 


### PR DESCRIPTION
Some translation paths use the <lang> string more than once, for instance the Joomla CMS use ./language/xx-XX/xx-XX.foo_bar.ini.  So translation_path() needs to use gsub for the substitution.