### PR TITLE
Category support

### DIFF
--- a/config/txgh.yml
+++ b/config/txgh.yml
@@ -2,14 +2,14 @@ txgh:
   github:
     repos:
       <%= ENV['TX_PUSH_TRANSLATIONS_TO'] %>:
-        api_username: <%= ENV['GITHUB_USERNAME'] %>
-        api_token: <%= ENV['GITHUB_TOKEN'] %>
-        push_source_to: <%= ENV['GITHUB_PUSH_SOURCE_TO'] %>
-        branch: <%= ENV['GITHUB_BRANCH'] %>
+        api_username: "<%= ENV['GITHUB_USERNAME'] %>"
+        api_token: "<%= ENV['GITHUB_TOKEN'] %>"
+        push_source_to: "<%= ENV['GITHUB_PUSH_SOURCE_TO'] %>"
+        branch: "<%= ENV['GITHUB_BRANCH'] %>"
   transifex:
     projects:
       <%= ENV['GITHUB_PUSH_SOURCE_TO'] %>:
-        tx_config: <%= ENV['TX_CONFIG_PATH'] %>
-        api_username: <%= ENV['TX_USERNAME'] %>
-        api_password: <%= ENV['TX_PASSWORD'] %>
-        push_translations_to: <%= ENV['TX_PUSH_TRANSLATIONS_TO'] %>
+        tx_config: "<%= ENV['TX_CONFIG_PATH'] %>"
+        api_username: "<%= ENV['TX_USERNAME'] %>"
+        api_password: "<%= ENV['TX_PASSWORD'] %>"
+        push_translations_to: "<%= ENV['TX_PUSH_TRANSLATIONS_TO'] %>"

--- a/lib/txgh/handlers/github_hook_handler.rb
+++ b/lib/txgh/handlers/github_hook_handler.rb
@@ -95,7 +95,7 @@ module Txgh
                 logger.info("process resource file: #{tx_resource.source_file}")
                 blob = github_api.blob(github_repo_name, file['sha'])
                 content = blob['encoding'] == 'utf-8' ? blob['content'] : Base64.decode64(blob['content'])
-                project.api.update(tx_resource, content)
+                project.api.create_or_update(tx_resource, content)
                 logger.info "updated tx_resource: #{tx_resource.inspect}"
               end
             end

--- a/lib/txgh/key_manager.rb
+++ b/lib/txgh/key_manager.rb
@@ -1,5 +1,6 @@
-require 'yaml'
+require 'erb'
 require 'etc'
+require 'yaml'
 
 module Txgh
   class KeyManager

--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -56,7 +56,7 @@ module Txgh
         slug: tx_resource.resource_slug,
         name: tx_resource.source_file,
         i18n_type: tx_resource.type,
-        categories: categories,
+        categories: categories.uniq,
         content: get_content_io(tx_resource, content)
       }
 
@@ -100,7 +100,7 @@ module Txgh
     end
 
     def get_resource(tx_resource)
-      url = "#{API_ROOT}/project/#{tx_resource.project_slug}/resource/#{tx_resource.resource_slug}"
+      url = "#{API_ROOT}/project/#{tx_resource.project_slug}/resource/#{tx_resource.resource_slug}/"
       response = connection.get(url)
       raise_error!(response)
       JSON.parse(response.body)

--- a/spec/handlers/github_hook_handler_spec.rb
+++ b/spec/handlers/github_hook_handler_spec.rb
@@ -58,7 +58,7 @@ describe GithubHookHandler do
       )
 
       expect(transifex_api).to(
-        receive(:update) do |resource, content|
+        receive(:create_or_update) do |resource, content|
           expect(resource.source_file).to eq(file['path'])
           expect(content).to eq(translations)
         end

--- a/spec/integration/cassettes/github_l10n_hook_endpoint.yml
+++ b/spec/integration/cassettes/github_l10n_hook_endpoint.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:20 GMT
+      - Mon, 25 Jan 2016 19:52:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -37,7 +37,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4993'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -62,12 +62,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Github-Request-Id:
-      - 04358C36:2071:18C921B:56A2D374
+      - 04358C36:175B1:7347075:56A67CF0
     body:
       encoding: UTF-8
       string: '{"message":"Reference already exists","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:16 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed
@@ -93,7 +93,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:21 GMT
+      - Mon, 25 Jan 2016 19:52:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -105,7 +105,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4992'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -139,9 +139,9 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - dc1ce2bfb41810a06c705e83b388572d
+      - bae57931a6fe678a3dffe9be8e7819c8
       X-Github-Request-Id:
-      - 04358C36:2075:440C943:56A2D375
+      - 04358C36:175AD:1FDCFD6:56A67CF0
     body:
       encoding: UTF-8
       string: '{"sha":"6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed","commit":{"author":{"name":"Matthew
@@ -150,7 +150,7 @@ http_interactions:
         -34,3 +34,5 @@ msgid \"Eight\"\n msgstr \"Eight\"\n msgid \"Nine\"\n msgstr
         \"Nine\"\n+msgid \"Ten\"\n+msgstr \"Ten\""}]}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:21 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:17 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50?recursive=1
@@ -176,7 +176,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:21 GMT
+      - Mon, 25 Jan 2016 19:52:17 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -188,7 +188,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4991'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -222,14 +222,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 7f48e2f7761567e923121f17538d7a6d
+      - 318e55760cf7cdb40e61175a4d36cd32
       X-Github-Request-Id:
-      - 04358C36:206D:670EEB:56A2D375
+      - 04358C36:175B3:580AC5B:56A67CF0
     body:
       encoding: UTF-8
       string: '{"sha":"572b0507c4109703788333808a0b0019c0000f50","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458"},{"path":"translations/el_GR","mode":"040000","type":"tree","sha":"396520f008766ce17de7b254cdfd3d7b4eda6b44","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/396520f008766ce17de7b254cdfd3d7b4eda6b44"},{"path":"translations/el_GR/sample.po","mode":"100644","type":"blob","sha":"98f5f909182137fd6416b4e672a85c013fef7a3a","size":1181,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/98f5f909182137fd6416b4e672a85c013fef7a3a"},{"path":"translations/el_GR/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"},{"path":"translations/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"}],"truncated":false}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:21 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:17 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6
@@ -255,7 +255,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:22 GMT
+      - Mon, 25 Jan 2016 19:52:17 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -267,7 +267,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4990'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -299,14 +299,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 52437fedc85beec8da3449496900fb9a
+      - 474556b853193c38f1b14328ce2d1b7d
       X-Github-Request-Id:
-      - 04358C36:2073:2F7B2DC:56A2D375
+      - 04358C36:175AF:410AFDB:56A67CF1
     body:
       encoding: UTF-8
       string: '{"sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6","content":"IyBUcmFuc2xhdGlvbiBmaWxlIGZvciBUcmFuc2lmZXguCiMgQ29weXJpZ2h0\nIChDKSAyMDA3LTIwMTAgSW5kaWZleCBMdGQuCiMgVGhpcyBmaWxlIGlzIGRp\nc3RyaWJ1dGVkIHVuZGVyIHRoZSBzYW1lIGxpY2Vuc2UgYXMgdGhlIFRyYW5z\naWZleCBwYWNrYWdlLgojCiMgVHJhbnNsYXRvcnM6Cm1zZ2lkICIiCm1zZ3N0\nciAiIgoiUHJvamVjdC1JZC1WZXJzaW9uOiBUcmFuc2lmZXhcbiIKIlJlcG9y\ndC1Nc2dpZC1CdWdzLVRvOiBcbiIKIlBPVC1DcmVhdGlvbi1EYXRlOiAyMDE1\nLTAyLTE3IDIwOjEwKzAwMDBcbiIKIlBPLVJldmlzaW9uLURhdGU6IDIwMTMt\nMTAtMjIgMTA6NTcrMDAwMFxuIgoiTGFzdC1UcmFuc2xhdG9yOiBJbGlhcy1E\naW1pdHJpb3MgVnJhY2huaXNcbiIKIkxhbmd1YWdlLVRlYW06IExBTkdVQUdF\nIDxMTEBsaS5vcmc+XG4iCiJMYW5ndWFnZTogZW5cbiIKIk1JTUUtVmVyc2lv\nbjogMS4wXG4iCiJDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9\nVVRGLThcbiIKIkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IDhiaXRcbiIK\nIlBsdXJhbC1Gb3JtczogbnBsdXJhbHM9MjsgcGx1cmFsPShuICE9IDEpO1xu\nIgptc2dpZCAiT25lIgptc2dzdHIgIk9uZSIKbXNnaWQgIlR3byIKbXNnc3Ry\nICJUd28iCm1zZ2lkICJUaHJlZSIKbXNnc3RyICJUaHJlZSIKbXNnaWQgIkZv\ndXIiCm1zZ3N0ciAiRm91ciIKbXNnaWQgIkZpdmUiCm1zZ3N0ciAiRml2ZSIK\nbXNnaWQgIlNpeCIKbXNnc3RyICJTaXgiCm1zZ2lkICJTZXZlbiIKbXNnc3Ry\nICJTZXZlbiIKbXNnaWQgIkVpZ2h0Igptc2dzdHIgIkVpZ2h0Igptc2dpZCAi\nTmluZSIKbXNnc3RyICJOaW5lIgptc2dpZCAiVGVuIgptc2dzdHIgIlRlbiIK\n","encoding":"base64"}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:22 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:18 GMT
 - request:
     method: get
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
@@ -335,9 +335,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 23 Jan 2016 01:12:22 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       Expires:
-      - Sat, 23 Jan 2016 01:12:22 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -347,21 +347,21 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
+      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:22 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: "{\n    \"source_language_code\": \"en\", \n    \"name\": \"sample.po\",
         \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
-        \n    \"categories\": null\n}"
+        \n    \"categories\": []\n}"
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:22 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:18 GMT
 - request:
     method: get
-    uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo
+    uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
     body:
       encoding: US-ASCII
       string: ''
@@ -387,9 +387,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 23 Jan 2016 01:12:23 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       Expires:
-      - Sat, 23 Jan 2016 01:12:23 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -399,18 +399,18 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
+      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:23 GMT
+      - Mon, 25 Jan 2016 19:52:18 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: "{\n    \"source_language_code\": \"en\", \n    \"name\": \"sample.po\",
         \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
-        \n    \"categories\": null\n}"
+        \n    \"categories\": []\n}"
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:23 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:19 GMT
 - request:
     method: put
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
@@ -441,9 +441,9 @@ http_interactions:
       Content-Type:
       - text/plain
       Date:
-      - Sat, 23 Jan 2016 01:12:24 GMT
+      - Mon, 25 Jan 2016 19:52:19 GMT
       Expires:
-      - Sat, 23 Jan 2016 01:12:24 GMT
+      - Mon, 25 Jan 2016 19:52:19 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -453,16 +453,16 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
+      - X-Mapping-fjhppofk=7BA9C65DD9CD0F1A96194A82BFB61D00; path=/
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:24 GMT
+      - Mon, 25 Jan 2016 19:52:19 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: OK
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:24 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:20 GMT
 - request:
     method: put
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/content/
@@ -508,9 +508,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 23 Jan 2016 01:12:25 GMT
+      - Mon, 25 Jan 2016 19:52:20 GMT
       Expires:
-      - Sat, 23 Jan 2016 01:12:25 GMT
+      - Mon, 25 Jan 2016 19:52:20 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -520,9 +520,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=7BA9C65DD9CD0F1A96194A82BFB61D00; path=/
+      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:25 GMT
+      - Mon, 25 Jan 2016 19:52:20 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -530,5 +530,5 @@ http_interactions:
       string: "{\n    \"strings_added\": 0, \n    \"strings_updated\": 0, \n    \"strings_delete\":
         0, \n    \"redirect\": \"/txgh-test/test-project-88/samplepo/\"\n}"
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:25 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:20 GMT
 recorded_with: VCR 3.0.1

--- a/spec/integration/cassettes/github_l10n_hook_endpoint.yml
+++ b/spec/integration/cassettes/github_l10n_hook_endpoint.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:04 GMT
+      - Sat, 23 Jan 2016 01:12:20 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -35,9 +35,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4933'
+      - '4993'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -62,12 +62,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Github-Request-Id:
-      - 04358C36:12182:F7FDD63:569E9E34
+      - 04358C36:2071:18C921B:56A2D374
     body:
       encoding: UTF-8
       string: '{"message":"Reference already exists","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:15 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed
@@ -93,7 +93,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:04 GMT
+      - Sat, 23 Jan 2016 01:12:21 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -103,9 +103,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4932'
+      - '4992'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -139,9 +139,9 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 593010132f82159af0ded24b4932e109
+      - dc1ce2bfb41810a06c705e83b388572d
       X-Github-Request-Id:
-      - 04358C36:1217B:359F265:569E9E34
+      - 04358C36:2075:440C943:56A2D375
     body:
       encoding: UTF-8
       string: '{"sha":"6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed","commit":{"author":{"name":"Matthew
@@ -150,7 +150,7 @@ http_interactions:
         -34,3 +34,5 @@ msgid \"Eight\"\n msgstr \"Eight\"\n msgid \"Nine\"\n msgstr
         \"Nine\"\n+msgid \"Ten\"\n+msgstr \"Ten\""}]}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:15 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:21 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50?recursive=1
@@ -176,7 +176,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:05 GMT
+      - Sat, 23 Jan 2016 01:12:21 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -186,9 +186,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4931'
+      - '4991'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -222,14 +222,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - bae57931a6fe678a3dffe9be8e7819c8
+      - 7f48e2f7761567e923121f17538d7a6d
       X-Github-Request-Id:
-      - 04358C36:1217C:4261A4A:569E9E35
+      - 04358C36:206D:670EEB:56A2D375
     body:
       encoding: UTF-8
       string: '{"sha":"572b0507c4109703788333808a0b0019c0000f50","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458"},{"path":"translations/el_GR","mode":"040000","type":"tree","sha":"396520f008766ce17de7b254cdfd3d7b4eda6b44","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/396520f008766ce17de7b254cdfd3d7b4eda6b44"},{"path":"translations/el_GR/sample.po","mode":"100644","type":"blob","sha":"98f5f909182137fd6416b4e672a85c013fef7a3a","size":1181,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/98f5f909182137fd6416b4e672a85c013fef7a3a"},{"path":"translations/el_GR/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"},{"path":"translations/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"}],"truncated":false}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:15 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:21 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6
@@ -255,7 +255,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:05 GMT
+      - Sat, 23 Jan 2016 01:12:22 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -265,9 +265,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4930'
+      - '4990'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -299,14 +299,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 173530fed4bbeb1e264b2ed22e8b5c20
+      - 52437fedc85beec8da3449496900fb9a
       X-Github-Request-Id:
-      - 04358C36:12180:DF5DB46:569E9E35
+      - 04358C36:2073:2F7B2DC:56A2D375
     body:
       encoding: UTF-8
       string: '{"sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6","content":"IyBUcmFuc2xhdGlvbiBmaWxlIGZvciBUcmFuc2lmZXguCiMgQ29weXJpZ2h0\nIChDKSAyMDA3LTIwMTAgSW5kaWZleCBMdGQuCiMgVGhpcyBmaWxlIGlzIGRp\nc3RyaWJ1dGVkIHVuZGVyIHRoZSBzYW1lIGxpY2Vuc2UgYXMgdGhlIFRyYW5z\naWZleCBwYWNrYWdlLgojCiMgVHJhbnNsYXRvcnM6Cm1zZ2lkICIiCm1zZ3N0\nciAiIgoiUHJvamVjdC1JZC1WZXJzaW9uOiBUcmFuc2lmZXhcbiIKIlJlcG9y\ndC1Nc2dpZC1CdWdzLVRvOiBcbiIKIlBPVC1DcmVhdGlvbi1EYXRlOiAyMDE1\nLTAyLTE3IDIwOjEwKzAwMDBcbiIKIlBPLVJldmlzaW9uLURhdGU6IDIwMTMt\nMTAtMjIgMTA6NTcrMDAwMFxuIgoiTGFzdC1UcmFuc2xhdG9yOiBJbGlhcy1E\naW1pdHJpb3MgVnJhY2huaXNcbiIKIkxhbmd1YWdlLVRlYW06IExBTkdVQUdF\nIDxMTEBsaS5vcmc+XG4iCiJMYW5ndWFnZTogZW5cbiIKIk1JTUUtVmVyc2lv\nbjogMS4wXG4iCiJDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9\nVVRGLThcbiIKIkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IDhiaXRcbiIK\nIlBsdXJhbC1Gb3JtczogbnBsdXJhbHM9MjsgcGx1cmFsPShuICE9IDEpO1xu\nIgptc2dpZCAiT25lIgptc2dzdHIgIk9uZSIKbXNnaWQgIlR3byIKbXNnc3Ry\nICJUd28iCm1zZ2lkICJUaHJlZSIKbXNnc3RyICJUaHJlZSIKbXNnaWQgIkZv\ndXIiCm1zZ3N0ciAiRm91ciIKbXNnaWQgIkZpdmUiCm1zZ3N0ciAiRml2ZSIK\nbXNnaWQgIlNpeCIKbXNnc3RyICJTaXgiCm1zZ2lkICJTZXZlbiIKbXNnc3Ry\nICJTZXZlbiIKbXNnaWQgIkVpZ2h0Igptc2dzdHIgIkVpZ2h0Igptc2dpZCAi\nTmluZSIKbXNnc3RyICJOaW5lIgptc2dpZCAiVGVuIgptc2dzdHIgIlRlbiIK\n","encoding":"base64"}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:16 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:22 GMT
 - request:
     method: get
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
@@ -335,9 +335,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2016 20:36:06 GMT
+      - Sat, 23 Jan 2016 01:12:22 GMT
       Expires:
-      - Tue, 19 Jan 2016 20:36:06 GMT
+      - Sat, 23 Jan 2016 01:12:22 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -347,9 +347,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=B8558B7BB369B761FC4CE03884ACF0F5; path=/
+      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
       Last-Modified:
-      - Tue, 19 Jan 2016 20:36:06 GMT
+      - Sat, 23 Jan 2016 01:12:22 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -358,7 +358,111 @@ http_interactions:
         \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
         \n    \"categories\": null\n}"
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:17 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:22 GMT
+- request:
+    method: get
+    uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Authorization, Host, Accept-Language, Cookie
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 23 Jan 2016 01:12:23 GMT
+      Expires:
+      - Sat, 23 Jan 2016 01:12:23 GMT
+      Transfer-Encoding:
+      - chunked
+      Content-Language:
+      - en
+      X-Content-Type-Options:
+      - nosniff
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
+      Last-Modified:
+      - Sat, 23 Jan 2016 01:12:23 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: "{\n    \"source_language_code\": \"en\", \n    \"name\": \"sample.po\",
+        \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
+        \n    \"categories\": null\n}"
+    http_version: 
+  recorded_at: Sat, 23 Jan 2016 01:12:23 GMT
+- request:
+    method: put
+    uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
+    body:
+      encoding: UTF-8
+      string: '{"categories":[]}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Authorization, Host, Accept-Language, Cookie
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - text/plain
+      Date:
+      - Sat, 23 Jan 2016 01:12:24 GMT
+      Expires:
+      - Sat, 23 Jan 2016 01:12:24 GMT
+      Transfer-Encoding:
+      - chunked
+      Content-Language:
+      - en
+      X-Content-Type-Options:
+      - nosniff
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
+      Last-Modified:
+      - Sat, 23 Jan 2016 01:12:24 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: OK
+    http_version: 
+  recorded_at: Sat, 23 Jan 2016 01:12:24 GMT
 - request:
     method: put
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/content/
@@ -404,9 +508,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2016 20:36:07 GMT
+      - Sat, 23 Jan 2016 01:12:25 GMT
       Expires:
-      - Tue, 19 Jan 2016 20:36:07 GMT
+      - Sat, 23 Jan 2016 01:12:25 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -416,9 +520,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=B8558B7BB369B761FC4CE03884ACF0F5; path=/
+      - X-Mapping-fjhppofk=7BA9C65DD9CD0F1A96194A82BFB61D00; path=/
       Last-Modified:
-      - Tue, 19 Jan 2016 20:36:07 GMT
+      - Sat, 23 Jan 2016 01:12:25 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -426,5 +530,5 @@ http_interactions:
       string: "{\n    \"strings_added\": 0, \n    \"strings_updated\": 0, \n    \"strings_delete\":
         0, \n    \"redirect\": \"/txgh-test/test-project-88/samplepo/\"\n}"
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:18 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Sat, 23 Jan 2016 01:12:25 GMT
+recorded_with: VCR 3.0.1

--- a/spec/integration/cassettes/transifex_hook_endpoint.yml
+++ b/spec/integration/cassettes/transifex_hook_endpoint.yml
@@ -28,9 +28,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2016 20:36:01 GMT
+      - Sat, 23 Jan 2016 01:12:18 GMT
       Expires:
-      - Tue, 19 Jan 2016 20:36:01 GMT
+      - Sat, 23 Jan 2016 01:12:18 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -42,7 +42,7 @@ http_interactions:
       Set-Cookie:
       - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
       Last-Modified:
-      - Tue, 19 Jan 2016 20:36:01 GMT
+      - Sat, 23 Jan 2016 01:12:18 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -63,7 +63,7 @@ http_interactions:
         \\\"Eight\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid \\\"Nine\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid
         \\\"Ten\\\"\\nmsgstr \\\"\\\"\\n\", \n    \"mimetype\": \"text/x-po\"\n}"
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:12 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs
@@ -101,7 +101,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:01 GMT
+      - Sat, 23 Jan 2016 01:12:18 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -111,9 +111,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4939'
+      - '4999'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -147,14 +147,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - a6882e5cd2513376cb9481dbcd83f3a2
+      - 065b43cd9674091fec48a221b420fbb3
       X-Github-Request-Id:
-      - 04358C36:12181:108CD951:569E9E31
+      - 04358C36:2076:2A13F75:56A2D372
     body:
       encoding: UTF-8
       string: '{"sha":"540a3d944ac19f573e756de687c8c4f3f9847b53","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/540a3d944ac19f573e756de687c8c4f3f9847b53"}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:12 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
@@ -180,7 +180,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:02 GMT
+      - Sat, 23 Jan 2016 01:12:18 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -190,15 +190,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4938'
+      - '4998'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
       - Mon, 11 Jan 2016 23:45:43 GMT
       Etag:
-      - W/"6e246bafa55ada434e7e365191652c97"
+      - W/"1e7c9a332c99e26054894d200fcba737"
       X-Poll-Interval:
       - '300'
       X-Oauth-Scopes:
@@ -228,17 +228,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 13d09b732ebe76f892093130dc088652
+      - 52437fedc85beec8da3449496900fb9a
       X-Github-Request-Id:
-      - 04358C36:12180:DF5D81C:569E9E32
+      - 04358C36:2070:10C76AA:56A2D372
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"33d77b9405900bd0bc9172e9bac23df90657342e","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/33d77b9405900bd0bc9172e9bac23df90657342e"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769"}}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:13 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/33d77b9405900bd0bc9172e9bac23df90657342e
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769
     body:
       encoding: US-ASCII
       string: ''
@@ -261,7 +261,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:02 GMT
+      - Sat, 23 Jan 2016 01:12:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -271,15 +271,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4937'
+      - '4997'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
-      - Tue, 19 Jan 2016 20:26:12 GMT
+      - Tue, 19 Jan 2016 20:36:03 GMT
       Etag:
-      - W/"2ccd34f2a5a612c6927ccbcd69040877"
+      - W/"14cac84ed223e232b0700fe5e4a7c790"
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -307,15 +307,15 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 07ff1c8a09e44b62e277fae50a1b1dc4
+      - a51acaae89a7607fd7ee967627be18e4
       X-Github-Request-Id:
-      - 04358C36:12179:26FFE2E:569E9E32
+      - 04358C36:2075:440C6E8:56A2D373
     body:
       encoding: UTF-8
-      string: '{"sha":"33d77b9405900bd0bc9172e9bac23df90657342e","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:26:12Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:26:12Z"},"message":"Updating
-        translations for translations/el_GR/sample.po [skip ci]","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/33d77b9405900bd0bc9172e9bac23df90657342e","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/33d77b9405900bd0bc9172e9bac23df90657342e","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/33d77b9405900bd0bc9172e9bac23df90657342e","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/33d77b9405900bd0bc9172e9bac23df90657342e/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"96c02d15c54811de9ca86d3ddd043d7950358f80","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/96c02d15c54811de9ca86d3ddd043d7950358f80","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/96c02d15c54811de9ca86d3ddd043d7950358f80"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
+      string: '{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"message":"Updating
+        translations for translations/el_GR/sample.po [skip ci]","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"33d77b9405900bd0bc9172e9bac23df90657342e","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/33d77b9405900bd0bc9172e9bac23df90657342e","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/33d77b9405900bd0bc9172e9bac23df90657342e"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:13 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:19 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees
@@ -341,7 +341,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:03 GMT
+      - Sat, 23 Jan 2016 01:12:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -351,9 +351,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4936'
+      - '4996'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -387,21 +387,20 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - a241e1a8264a6ace03db946c85b92db3
+      - 7f48e2f7761567e923121f17538d7a6d
       X-Github-Request-Id:
-      - 04358C36:12180:DF5D8F5:569E9E32
+      - 04358C36:2074:3B8519A:56A2D373
     body:
       encoding: UTF-8
       string: '{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"64881902c6515e26c22e022abc0bedeaa15eafdc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/64881902c6515e26c22e022abc0bedeaa15eafdc"}],"truncated":false}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:13 GMT
+  recorded_at: Sat, 23 Jan 2016 01:12:19 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits
     body:
       encoding: UTF-8
-      string: '{"message":"Updating translations for translations/el_GR/sample.po
-        [skip ci]","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["33d77b9405900bd0bc9172e9bac23df90657342e"]}'
+      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["0ed84551e879a3fe3181bb758b08f792ebec4769"]}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -421,107 +420,29 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 19 Jan 2016 20:36:03 GMT
+      - Sat, 23 Jan 2016 01:12:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1000'
+      - '990'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4935'
+      - '4995'
       X-Ratelimit-Reset:
-      - '1453236487'
+      - '1453515138'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
-      - '"b3bf0b9ce9daac0b164395f87ce7be2f"'
+      - '"1cbbafbc938a650aad1b9398e8ba5ef3"'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Served-By:
-      - a6882e5cd2513376cb9481dbcd83f3a2
-      X-Github-Request-Id:
-      - 04358C36:1217B:359F229:569E9E33
-    body:
-      encoding: UTF-8
-      string: '{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
-        translations for translations/el_GR/sample.po [skip ci]","parents":[{"sha":"33d77b9405900bd0bc9172e9bac23df90657342e","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/33d77b9405900bd0bc9172e9bac23df90657342e","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/33d77b9405900bd0bc9172e9bac23df90657342e"}]}'
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:14 GMT
-- request:
-    method: patch
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
-    body:
-      encoding: UTF-8
-      string: '{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","force":true}'
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 4.2.0
-      Content-Type:
-      - application/json
-      Authorization:
-      - token <GITHUB_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 19 Jan 2016 20:36:03 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4934'
-      X-Ratelimit-Reset:
-      - '1453236487'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Etag:
-      - W/"1e7c9a332c99e26054894d200fcba737"
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - ''
+      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       - Accept-Encoding
@@ -547,10 +468,88 @@ http_interactions:
       X-Served-By:
       - 593010132f82159af0ded24b4932e109
       X-Github-Request-Id:
-      - 04358C36:12181:108CDBDC:569E9E33
+      - 04358C36:2076:2A14096:56A2D373
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769"}}'
+      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
+        translations for translations/el_GR/sample.po","parents":[{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769"}]}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 20:36:14 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
+- request:
+    method: patch
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
+    body:
+      encoding: UTF-8
+      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","force":true}'
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sat, 23 Jan 2016 01:12:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1453515138'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Etag:
+      - W/"2b6917f18180a72bbe11323d56090489"
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 139317cebd6caf9cd03889139437f00b
+      X-Github-Request-Id:
+      - 04358C36:2075:440C841:56A2D374
+    body:
+      encoding: UTF-8
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"6ea48545155f561b142e730f7284961b312090fc","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc"}}'
+    http_version: 
+  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/integration/cassettes/transifex_hook_endpoint.yml
+++ b/spec/integration/cassettes/transifex_hook_endpoint.yml
@@ -28,9 +28,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 23 Jan 2016 01:12:18 GMT
+      - Mon, 25 Jan 2016 19:52:12 GMT
       Expires:
-      - Sat, 23 Jan 2016 01:12:18 GMT
+      - Mon, 25 Jan 2016 19:52:12 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -40,9 +40,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
+      - X-Mapping-fjhppofk=D7F0B90A7FEFB2573FEF4C177EEBE6A8; path=/
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:18 GMT
+      - Mon, 25 Jan 2016 19:52:12 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -63,7 +63,7 @@ http_interactions:
         \\\"Eight\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid \\\"Nine\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid
         \\\"Ten\\\"\\nmsgstr \\\"\\\"\\n\", \n    \"mimetype\": \"text/x-po\"\n}"
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:12 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs
@@ -101,7 +101,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:18 GMT
+      - Mon, 25 Jan 2016 19:52:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -113,7 +113,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4999'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -147,14 +147,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 065b43cd9674091fec48a221b420fbb3
+      - 173530fed4bbeb1e264b2ed22e8b5c20
       X-Github-Request-Id:
-      - 04358C36:2076:2A13F75:56A2D372
+      - 04358C36:175B0:5A724C7:56A67CEC
     body:
       encoding: UTF-8
       string: '{"sha":"540a3d944ac19f573e756de687c8c4f3f9847b53","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/540a3d944ac19f573e756de687c8c4f3f9847b53"}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:14 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
@@ -180,7 +180,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:18 GMT
+      - Mon, 25 Jan 2016 19:52:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -192,13 +192,13 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4998'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
       - Mon, 11 Jan 2016 23:45:43 GMT
       Etag:
-      - W/"1e7c9a332c99e26054894d200fcba737"
+      - W/"2b6917f18180a72bbe11323d56090489"
       X-Poll-Interval:
       - '300'
       X-Oauth-Scopes:
@@ -228,17 +228,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 52437fedc85beec8da3449496900fb9a
+      - d594a23ec74671eba905bf91ef329026
       X-Github-Request-Id:
-      - 04358C36:2070:10C76AA:56A2D372
+      - 04358C36:175AB:FE5639:56A67CEE
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"6ea48545155f561b142e730f7284961b312090fc","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc"}}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:18 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:14 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc
     body:
       encoding: US-ASCII
       string: ''
@@ -261,7 +261,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:19 GMT
+      - Mon, 25 Jan 2016 19:52:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -273,13 +273,13 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4997'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
-      - Tue, 19 Jan 2016 20:36:03 GMT
+      - Sat, 23 Jan 2016 01:12:19 GMT
       Etag:
-      - W/"14cac84ed223e232b0700fe5e4a7c790"
+      - W/"ab77d4b0a5e9d218c6cb2b4cde3b771b"
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -307,15 +307,15 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - a51acaae89a7607fd7ee967627be18e4
+      - 139317cebd6caf9cd03889139437f00b
       X-Github-Request-Id:
-      - 04358C36:2075:440C6E8:56A2D373
+      - 04358C36:175B1:7346E44:56A67CEE
     body:
       encoding: UTF-8
-      string: '{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-19T20:36:03Z"},"message":"Updating
-        translations for translations/el_GR/sample.po [skip ci]","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"33d77b9405900bd0bc9172e9bac23df90657342e","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/33d77b9405900bd0bc9172e9bac23df90657342e","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/33d77b9405900bd0bc9172e9bac23df90657342e"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
+      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:19 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees
@@ -341,7 +341,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:19 GMT
+      - Mon, 25 Jan 2016 19:52:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -353,7 +353,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4996'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -387,20 +387,20 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 7f48e2f7761567e923121f17538d7a6d
+      - c6c65e5196703428e7641f7d1e9bc353
       X-Github-Request-Id:
-      - 04358C36:2074:3B8519A:56A2D373
+      - 04358C36:175B3:580AABD:56A67CEE
     body:
       encoding: UTF-8
       string: '{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"64881902c6515e26c22e022abc0bedeaa15eafdc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/64881902c6515e26c22e022abc0bedeaa15eafdc"}],"truncated":false}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:19 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits
     body:
       encoding: UTF-8
-      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["0ed84551e879a3fe3181bb758b08f792ebec4769"]}'
+      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["6ea48545155f561b142e730f7284961b312090fc"]}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -420,7 +420,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:19 GMT
+      - Mon, 25 Jan 2016 19:52:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -432,17 +432,17 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4995'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
-      - '"1cbbafbc938a650aad1b9398e8ba5ef3"'
+      - '"23db945e0f6a850200970c3b09c4376d"'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc
+      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       - Accept-Encoding
@@ -468,19 +468,19 @@ http_interactions:
       X-Served-By:
       - 593010132f82159af0ded24b4932e109
       X-Github-Request-Id:
-      - 04358C36:2076:2A14096:56A2D373
+      - 04358C36:175AE:2DEA956:56A67CEF
     body:
       encoding: UTF-8
-      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
-        translations for translations/el_GR/sample.po","parents":[{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769"}]}'
+      string: '{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/dd6f7c2301400a36475306556d7da1e56b7477e1","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T19:52:15Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T19:52:15Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
+        translations for translations/el_GR/sample.po","parents":[{"sha":"6ea48545155f561b142e730f7284961b312090fc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc"}]}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
 - request:
     method: patch
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
     body:
       encoding: UTF-8
-      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","force":true}'
+      string: '{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","force":true}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -500,7 +500,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sat, 23 Jan 2016 01:12:20 GMT
+      - Mon, 25 Jan 2016 19:52:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -512,11 +512,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4994'
       X-Ratelimit-Reset:
-      - '1453515138'
+      - '1453755132'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
-      - W/"2b6917f18180a72bbe11323d56090489"
+      - W/"38da3d7f7e3ba497adac4b879211dae1"
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -544,12 +544,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 139317cebd6caf9cd03889139437f00b
+      - 7b641bda7ec2ca7cd9df72d2578baf75
       X-Github-Request-Id:
-      - 04358C36:2075:440C841:56A2D374
+      - 04358C36:175B2:841DADB:56A67CEF
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"6ea48545155f561b142e730f7284961b312090fc","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1"}}'
     http_version: 
-  recorded_at: Sat, 23 Jan 2016 01:12:20 GMT
+  recorded_at: Mon, 25 Jan 2016 19:52:16 GMT
 recorded_with: VCR 3.0.1

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -12,23 +12,35 @@ describe TransifexApi do
 
   describe '#create_or_update' do
     context 'with a preexisting resource' do
-      it 'makes a request with the correct parameters' do
-        # expect(connection).to receive(:put) do |url, payload|
-        #   expect(url).to(
-        #     end_with("project/#{project_name}/resource/#{resource_slug}/content/")
-        #   )
-
-        #   response
-        # end
-
+      before(:each) do
         expect(api).to receive(:resource_exists?).and_return(true)
+      end
+
+      it 'updates the resource with new content' do
         expect(api).to receive(:update_details).with(resource, categories: [])
         expect(api).to receive(:update_content).with(resource, 'new_content')
         expect(api).to receive(:get_resource).and_return({})
 
-        allow(response).to receive(:status).and_return(200)
-        allow(response).to receive(:body).and_return('{}')
         api.create_or_update(resource, 'new_content')
+      end
+
+      it "additively updates the resource's categories" do
+        expect(api).to receive(:update_details) do |rsrc, details|
+          expect(details[:categories].sort).to eq(['branch:foobar', 'name:Jesse James'])
+        end
+
+        expect(api).to receive(:update_content).with(resource, 'new_content')
+        expect(api).to receive(:get_resource).and_return({ 'categories' => ['name:Jesse James'] })
+
+        api.create_or_update(resource, 'new_content', ['branch:foobar'])
+      end
+
+      it 'only submits a unique set of categories' do
+        expect(api).to receive(:update_details).with(resource, categories: ['branch:foobar'])
+        expect(api).to receive(:update_content).with(resource, 'new_content')
+        expect(api).to receive(:get_resource).and_return({ 'categories' => ['branch:foobar'] })
+
+        api.create_or_update(resource, 'new_content', ['branch:foobar'])
       end
     end
 
@@ -54,6 +66,87 @@ describe TransifexApi do
         allow(response).to receive(:body).and_return("{}")
         api.create_or_update(resource, 'new_content')
       end
+    end
+  end
+
+  describe '#create' do
+    it 'makes a request with the correct parameters' do
+      expect(connection).to receive(:post) do |url, payload|
+        expect(url).to(
+          end_with("project/#{project_name}/resources/")
+        )
+
+        expect(payload[:content].io.string).to eq('new_content')
+        expect(payload[:categories]).to eq(['abc'])
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      api.create(resource, 'new_content', ['abc'])
+    end
+
+    it 'submits de-duped categories' do
+      expect(connection).to receive(:post) do |url, payload|
+        expect(payload[:categories]).to eq(['abc'])
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      api.create(resource, 'new_content', ['abc', 'abc'])
+    end
+
+    it 'raises an exception if the api responds with an error code' do
+      allow(connection).to receive(:post).and_return(response)
+      allow(response).to receive(:status).and_return(404)
+      allow(response).to receive(:body).and_return('{}')
+      expect { api.create(resource, 'new_content') }.to raise_error(TransifexApiError)
+    end
+  end
+
+  describe '#update_content' do
+    it 'makes a request with the correct parameters' do
+      expect(connection).to receive(:put) do |url, payload|
+        expect(url).to(
+          end_with("project/#{project_name}/resource/#{resource_slug}/content/")
+        )
+
+        expect(payload[:content].io.string).to eq('new_content')
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      api.update_content(resource, 'new_content')
+    end
+
+    it 'raises an exception if the api responds with an error code' do
+      allow(connection).to receive(:put).and_return(response)
+      allow(response).to receive(:status).and_return(404)
+      allow(response).to receive(:body).and_return('{}')
+      expect { api.update_content(resource, 'new_content') }.to raise_error(TransifexApiError)
+    end
+  end
+
+  describe '#update_details' do
+    it 'makes a request with the correct parameters' do
+      expect(connection).to receive(:put) do |url, payload|
+        expect(url).to(
+          end_with("project/#{project_name}/resource/#{resource_slug}/")
+        )
+
+        expect(payload[:i18n_type]).to eq('FOO')
+        expect(payload[:categories]).to eq(['abc'])
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      api.update_details(resource, i18n_type: 'FOO', categories: ['abc'])
+    end
+
+    it 'raises an exception if the api responds with an error code' do
+      allow(connection).to receive(:put).and_return(response)
+      allow(response).to receive(:status).and_return(404)
+      allow(response).to receive(:body).and_return('{}')
+      expect { api.update_details(resource, {}) }.to raise_error(TransifexApiError)
     end
   end
 
@@ -113,6 +206,29 @@ describe TransifexApi do
       allow(response).to receive(:status).and_return(404)
       allow(response).to receive(:body).and_return('{}')
       expect { api.download(resource, language) }.to raise_error(TransifexApiError)
+    end
+  end
+
+  describe '#get_resource' do
+    it 'makes a request with the correct parameters' do
+      expect(connection).to receive(:get) do |url, payload|
+        expect(url).to(
+          end_with("project/#{project_name}/resource/#{resource_slug}/")
+        )
+
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      expect(response).to receive(:body).and_return('{"foo":"bar"}')
+      expect(api.get_resource(resource)).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'raises an exception if the api responds with an error code' do
+      allow(connection).to receive(:get).and_return(response)
+      allow(response).to receive(:status).and_return(404)
+      allow(response).to receive(:body).and_return('{}')
+      expect { api.get_resource(resource) }.to raise_error(TransifexApiError)
     end
   end
 end

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -10,38 +10,25 @@ describe TransifexApi do
   let(:resource) { transifex_project.resources.first }
   let(:response) { double(:response) }
 
-  describe '#update' do
+  describe '#create_or_update' do
     context 'with a preexisting resource' do
-      before(:each) do
-        expect(api).to receive(:resource_exists?).and_return(true)
-      end
-
       it 'makes a request with the correct parameters' do
-        expect(connection).to receive(:put) do |url, payload|
-          expect(url).to(
-            end_with("project/#{project_name}/resource/#{resource_slug}/content/")
-          )
+        # expect(connection).to receive(:put) do |url, payload|
+        #   expect(url).to(
+        #     end_with("project/#{project_name}/resource/#{resource_slug}/content/")
+        #   )
 
-          response
-        end
+        #   response
+        # end
+
+        expect(api).to receive(:resource_exists?).and_return(true)
+        expect(api).to receive(:update_details).with(resource, categories: [])
+        expect(api).to receive(:update_content).with(resource, 'new_content')
+        expect(api).to receive(:get_resource).and_return({})
 
         allow(response).to receive(:status).and_return(200)
         allow(response).to receive(:body).and_return('{}')
-        api.update(resource, 'new_content')
-      end
-
-      it 'returns the response body on a successful request' do
-        allow(connection).to receive(:put).and_return(response)
-        allow(response).to receive(:status).and_return(200)
-        allow(response).to receive(:body).and_return('{"foo": "bar"}')
-        expect(api.update(resource, 'new content')).to eq('foo' => 'bar')
-      end
-
-      it 'raises an error on an unsuccessful request' do
-        allow(connection).to receive(:put).and_return(response)
-        allow(response).to receive(:status).and_return(404)
-        allow(response).to receive(:body).and_return('{}')
-        expect { api.update(resource, 'new content') }.to raise_error(TransifexApiError)
+        api.create_or_update(resource, 'new_content')
       end
     end
 
@@ -65,21 +52,7 @@ describe TransifexApi do
 
         allow(response).to receive(:status).and_return(200)
         allow(response).to receive(:body).and_return("{}")
-        api.update(resource, 'new_content')
-      end
-
-      it 'returns the response body on a successful request' do
-        allow(connection).to receive(:post).and_return(response)
-        allow(response).to receive(:status).and_return(200)
-        allow(response).to receive(:body).and_return('{"foo": "bar"}')
-        expect(api.update(resource, 'new content')).to eq('foo' => 'bar')
-      end
-
-      it 'raises an error on an unsuccessful request' do
-        allow(connection).to receive(:post).and_return(response)
-        allow(response).to receive(:status).and_return(404)
-        allow(response).to receive(:body).and_return('{}')
-        expect { api.update(resource, 'new content') }.to raise_error(TransifexApiError)
+        api.create_or_update(resource, 'new_content')
       end
     end
   end


### PR DESCRIPTION
In preparation for supporting multiple branches, this PR adds the ability to associate Transifex categories with resources. The idea here is that eventually we'll be able to tag resources with categories like `branch:master` and `author:Sylvester Stallone`, etc.

@jdoconnor @st33b @zvkemp