### PR TITLE
Multi-branch support

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,16 @@
 require_relative 'bootstrap'
 require 'txgh'
 
+if ENV['TX_CONFIG']
+  FileUtils.mkdir_p('./config')
+  File.write('./config/tx.config', ENV['TX_CONFIG'])
+end
+
+if ENV['TX_YAML']
+  FileUtils.mkdir_p('./config')
+  File.write('./config/txgh.yml', ENV['TX_YAML'])
+end
+
 map '/' do
   use Txgh::Application
   run Sinatra::Base

--- a/config.ru
+++ b/config.ru
@@ -1,16 +1,6 @@
 require_relative 'bootstrap'
 require 'txgh'
 
-if ENV['TX_CONFIG']
-  FileUtils.mkdir_p('./config')
-  File.write('./config/tx.config', ENV['TX_CONFIG'])
-end
-
-if ENV['TX_YAML']
-  FileUtils.mkdir_p('./config')
-  File.write('./config/txgh.yml', ENV['TX_YAML'])
-end
-
 map '/' do
   use Txgh::Application
   run Sinatra::Base

--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -1,5 +1,8 @@
+require 'txgh/errors'
+
 module Txgh
   autoload :Application,      'txgh/app'
+  autoload :CategorySupport,  'txgh/category_support'
   autoload :Config,           'txgh/config'
   autoload :GithubApi,        'txgh/github_api'
   autoload :GithubRepo,       'txgh/github_repo'
@@ -9,7 +12,9 @@ module Txgh
   autoload :ParseConfig,      'txgh/parse_config'
   autoload :TransifexApi,     'txgh/transifex_api'
   autoload :TransifexProject, 'txgh/transifex_project'
+  autoload :TxBranchResource, 'txgh/tx_branch_resource'
   autoload :TxConfig,         'txgh/tx_config'
   autoload :TxLogger,         'txgh/tx_logger'
   autoload :TxResource,       'txgh/tx_resource'
+  autoload :Utils,            'txgh/utils'
 end

--- a/lib/txgh/app.rb
+++ b/lib/txgh/app.rb
@@ -56,7 +56,7 @@ module Txgh
       handler = transifex_handler_for(
         project: config.transifex_project,
         repo: config.github_repo,
-        resource: request['resource'],
+        resource_slug: request['resource'],
         language: request['language'],
         logger: settings.logger
       )

--- a/lib/txgh/app.rb
+++ b/lib/txgh/app.rb
@@ -62,6 +62,7 @@ module Txgh
       )
 
       handler.execute
+      status 200
     end
 
     post '/github' do
@@ -86,6 +87,7 @@ module Txgh
       )
 
       handler.execute
+      status 200
     end
 
     private

--- a/lib/txgh/category_support.rb
+++ b/lib/txgh/category_support.rb
@@ -1,0 +1,29 @@
+module Txgh
+  module CategorySupport
+    def deserialize_categories(categories_arr)
+      categories_arr.each_with_object({}) do |category, ret|
+        if idx = category.index(':')
+          ret[category[0...idx]] = category[(idx + 1)..-1]
+        end
+      end
+    end
+
+    def serialize_categories(categories_hash)
+      categories_hash.map do |key, value|
+        "#{key}:#{value}"
+      end
+    end
+
+    def categorify(str)
+      str.gsub(' ', '_')
+    end
+
+    def join_categories(arr)
+      arr.join(' ')
+    end
+  end
+
+  # add all the methods as class methods (they're also available as instance
+  # methods for anyone who includes this module)
+  CategorySupport.extend(CategorySupport)
+end

--- a/lib/txgh/category_support.rb
+++ b/lib/txgh/category_support.rb
@@ -14,7 +14,7 @@ module Txgh
       end
     end
 
-    def categorify(str)
+    def escape_category(str)
       str.gsub(' ', '_')
     end
 

--- a/lib/txgh/category_support.rb
+++ b/lib/txgh/category_support.rb
@@ -1,9 +1,11 @@
 module Txgh
   module CategorySupport
     def deserialize_categories(categories_arr)
-      categories_arr.each_with_object({}) do |category, ret|
-        if idx = category.index(':')
-          ret[category[0...idx]] = category[(idx + 1)..-1]
+      categories_arr.each_with_object({}) do |category_str, ret|
+        category_str.split(' ').each do |category|
+          if idx = category.index(':')
+            ret[category[0...idx]] = category[(idx + 1)..-1]
+          end
         end
       end
     end

--- a/lib/txgh/errors.rb
+++ b/lib/txgh/errors.rb
@@ -1,0 +1,6 @@
+module Txgh
+  class TxghError < StandardError; end
+  class TxghInternalError < TxghError; end
+
+  class TransifexApiError < StandardError; end
+end

--- a/lib/txgh/handlers/github_hook_handler.rb
+++ b/lib/txgh/handlers/github_hook_handler.rb
@@ -93,7 +93,7 @@ module Txgh
         end
 
         categories['branch'] ||= branch
-        categories['author'] ||= categorify(
+        categories['author'] ||= escape_category(
           payload['head_commit']['committer']['name']
         )
 

--- a/lib/txgh/handlers/github_hook_handler.rb
+++ b/lib/txgh/handlers/github_hook_handler.rb
@@ -42,8 +42,6 @@ module Txgh
           end
 
           update_resources(modified_resources)
-
-          200
         end
       end
 

--- a/lib/txgh/handlers/github_hook_handler.rb
+++ b/lib/txgh/handlers/github_hook_handler.rb
@@ -4,6 +4,8 @@ require 'logger'
 module Txgh
   module Handlers
     class GithubHookHandler
+      include Txgh::CategorySupport
+
       attr_reader :project, :repo, :payload, :logger
 
       def initialize(options = {})
@@ -14,41 +16,19 @@ module Txgh
       end
 
       def execute
-        branch = payload['ref']
-        github_repo_name = repo.name
-        github_config_branch = repo.branch || 'master'
-
-        unless github_config_branch.include?('tags/')
-          github_config_branch = "heads/#{github_config_branch}"
-        end
-
         # Check if the branch in the hook data is the configured branch we want
         logger.info("request github branch: #{branch}")
         logger.info("config github branch: #{github_config_branch}")
 
-        if branch.include?(github_config_branch) || branch.include?('L10N')
+        if should_process_branch?
           logger.info('found branch in github request')
 
-          # Build an index of known Tx resources, by source file
-          tx_resources = {}
-          project.resources.each do |resource|
-            logger.info('processing resource')
-            tx_resources[resource.source_file] = resource
-          end
+          tx_resources = tx_resources_for(branch)
+          modified_resources = modified_resources_for(tx_resources)
+          modified_resources.merge!(l10n_resources_for(tx_resources))
 
-          # Finds the updated resources and maps the most recent commit in which
-          # each was modified
-          updated_resources = {}
-          payload['commits'].each do |commit|
-            logger.info('processing commit')
-
-            commit['modified'].each do |modified|
-              logger.info("processing modified file: #{modified}")
-
-              if tx_resources.include?(modified)
-                updated_resources[tx_resources[modified]] = commit['id']
-              end
-            end
+          if github_config_branch.include?('tags/')
+            modified_resources.merge!(tag_resources_for(tx_resources))
           end
 
           # Handle DBZ 'L10N' special case
@@ -56,53 +36,153 @@ module Txgh
             logger.info('processing L10N tag')
 
             # Create a new branch off tag commit
-            if branch.include?('refs/tags/L10N')
+            if branch.include?('tags/L10N')
               repo.api.create_ref(repo.name, 'heads/L10N', payload['head_commit']['id'])
             end
-
-            # Create new resources that include 'L10N'
-            payload['head_commit']['modified'].each do |modified|
-              logger.info("setting new resource: #{tx_resources[modified].L10N_resource_slug}")
-
-              if tx_resources.include?(modified)
-                updated_resources[tx_resources[modified]] = payload['head_commit']['id']
-              end
-            end
           end
 
-          if github_config_branch.include?('tags/')
-            payload['head_commit']['modified'].each do |modified|
-              logger.info("processing modified file: #{modified}")
-
-              if tx_resources.include?(modified)
-                updated_resources[tx_resources[modified]] = payload['head_commit']['id']
-              end
-            end
-          end
-
-          # For each modified resource, get its content and update the content
-          # in Transifex.
-          updated_resources.each do |tx_resource, commit_sha|
-            logger.info('process updated resource')
-            github_api = repo.api
-            tree_sha = github_api.get_commit(github_repo_name, commit_sha)['commit']['tree']['sha']
-            tree = github_api.tree(github_repo_name, tree_sha)
-
-            tree['tree'].each do |file|
-              logger.info("process each tree entry: #{file['path']}")
-
-              if tx_resource.source_file == file['path']
-                logger.info("process resource file: #{tx_resource.source_file}")
-                blob = github_api.blob(github_repo_name, file['sha'])
-                content = blob['encoding'] == 'utf-8' ? blob['content'] : Base64.decode64(blob['content'])
-                project.api.create_or_update(tx_resource, content)
-                logger.info "updated tx_resource: #{tx_resource.inspect}"
-              end
-            end
-          end
+          update_resources(modified_resources)
 
           200
         end
+      end
+
+      private
+
+      # For each modified resource, get its content and update the content
+      # in Transifex.
+      def update_resources(resources)
+        resources.each do |tx_resource, commit_sha|
+          logger.info('process updated resource')
+          github_api = repo.api
+          tree_sha = github_api.get_commit(repo.name, commit_sha)['commit']['tree']['sha']
+          tree = github_api.tree(repo.name, tree_sha)
+
+          tree['tree'].each do |file|
+            logger.info("process each tree entry: #{file['path']}")
+
+            if tx_resource.source_file == file['path']
+              logger.info("process resource file: #{tx_resource.source_file}")
+              blob = github_api.blob(repo.name, file['sha'])
+              content = blob['encoding'] == 'utf-8' ? blob['content'] : Base64.decode64(blob['content'])
+
+              if upload_by_branch?
+                upload_by_branch(tx_resource, content)
+              else
+                upload(tx_resource, content)
+              end
+
+              logger.info "updated tx_resource: #{tx_resource.inspect}"
+            end
+          end
+        end
+      end
+
+      def upload(tx_resource, content)
+        project.api.create_or_update(tx_resource, content)
+      end
+
+      def upload_by_branch(tx_resource, content)
+        resource_exists = project.api.resource_exists?(tx_resource)
+
+        categories = if resource_exists
+          resource = project.api.get_resource(*tx_resource.slugs)
+          deserialize_categories(Array(resource['categories']))
+        else
+          {}
+        end
+
+        categories['branch'] ||= branch
+        categories['author'] ||= categorify(
+          payload['head_commit']['committer']['name']
+        )
+
+        categories = serialize_categories(categories)
+
+        if resource_exists
+          project.api.update_details(tx_resource, categories: categories)
+          project.api.update_content(tx_resource, content)
+        else
+          project.api.create(tx_resource, content, categories)
+        end
+      end
+
+      def tag_resources_for(tx_resources)
+        payload['head_commit']['modified'].each_with_object({}) do |modified, ret|
+          # logger.info("processing modified file: #{modified}")
+
+          if tx_resources.include?(modified)
+            ret[tx_resources[modified]] = payload['head_commit']['id']
+          end
+        end
+      end
+
+      def l10n_resources_for(tx_resources)
+        payload['head_commit']['modified'].each_with_object({}) do |modified, ret|
+          # logger.info("setting new resource: #{tx_resources[modified].L10N_resource_slug}")
+
+          if tx_resources.include?(modified)
+            ret[tx_resources[modified]] = payload['head_commit']['id']
+          end
+        end
+      end
+
+      # Finds the updated resources and maps the most recent commit in which
+      # each was modified
+      def modified_resources_for(tx_resources)
+        payload['commits'].each_with_object({}) do |commit, ret|
+          logger.info('processing commit')
+
+          commit['modified'].each do |modified|
+            logger.info("processing modified file: #{modified}")
+
+            if tx_resources.include?(modified)
+              ret[tx_resources[modified]] = commit['id']
+            end
+          end
+        end
+      end
+
+      # Build an index of known Tx resources, by source file
+      def tx_resources_for(branch)
+        project.resources.each_with_object({}) do |resource, ret|
+          logger.info('processing resource')
+
+          # If we're processing by branch, create a branch resource. Otherwise,
+          # use the original resource.
+          ret[resource.source_file] = if upload_by_branch?
+            TxBranchResource.new(resource, branch)
+          else
+            resource
+          end
+        end
+      end
+
+      def should_process_branch?
+        process_all_branches? || (
+          branch.include?(github_config_branch) || branch.include?('L10N')
+        )
+      end
+
+      def github_config_branch
+        @github_config_branch = begin
+          if repo.branch == 'all'
+            repo.branch
+          else
+            branch = repo.branch || 'master'
+            branch.include?('tags/') ? branch : "heads/#{branch}"
+          end
+        end
+      end
+
+      def process_all_branches?
+        github_config_branch == 'all'
+      end
+
+      alias_method :upload_by_branch?, :process_all_branches?
+
+      def branch
+        @ref ||= payload['ref'].sub(/^refs\//, '')
       end
     end
   end

--- a/lib/txgh/handlers/transifex_hook_handler.rb
+++ b/lib/txgh/handlers/transifex_hook_handler.rb
@@ -3,46 +3,79 @@ require 'logger'
 module Txgh
   module Handlers
     class TransifexHookHandler
-      attr_reader :project, :repo, :resource, :language, :logger
+      include Txgh::CategorySupport
+
+      attr_reader :project, :repo, :resource_slug, :language, :logger
 
       def initialize(options = {})
         @project = options.fetch(:project)
         @repo = options.fetch(:repo)
-        @resource = options.fetch(:resource)
+        @resource_slug = options.fetch(:resource_slug)
         @language = options.fetch(:language)
         @logger = options.fetch(:logger) { Logger.new(STDOUT) }
       end
 
       def execute
-        tx_resource = project.resource(resource)
+        logger.info(resource_slug)
 
-        logger.info(resource)
-
+        if tx_resource
         # Do not update the source
-        unless language == tx_resource.source_lang
-          logger.info('request language matches resource')
+          unless language == tx_resource.source_lang
+            logger.info('request language matches resource')
 
-          translation = project.api.download(tx_resource, language)
+            translations = project.api.download(tx_resource, language)
 
-          if tx_resource.lang_map(language) != language
-            logger.info('request language is in lang_map and is not in request')
-            translation_path = tx_resource.translation_path(tx_resource.lang_map(language))
-          else
-            logger.info('request language is in lang_map and is in request or is nil')
-            translation_path = tx_resource.translation_path(project.lang_map(language))
+            translation_path = if tx_resource.lang_map(language) != language
+              logger.info('request language is in lang_map and is not in request')
+              tx_resource.translation_path(tx_resource.lang_map(language))
+            else
+              logger.info('request language is in lang_map and is in request or is nil')
+              tx_resource.translation_path(project.lang_map(language))
+            end
+
+            logger.info("make github commit for branch: #{branch}")
+
+            repo.api.commit(
+              repo.name, branch, translation_path, translations
+            )
           end
-
-          github_branch = repo.branch || 'master'
-          github_branch = github_branch.include?("tags/") ? github_branch : "heads/#{github_branch}"
-
-          logger.info("make github commit for branch: #{github_branch}")
-
-          repo.api.commit(
-            repo.name, github_branch, translation_path, translation
-          )
+        else
+          raise TxghError,
+            "Could not find configuration for resource '#{resource_slug}'"
         end
       end
 
+      private
+
+      def branch
+        branch_candidate = if process_all_branches?
+          tx_resource.branch
+        else
+          repo.branch || 'master'
+        end
+
+        if branch_candidate.include?('tags/')
+          branch_candidate
+        elsif branch_candidate.include?('heads/')
+          branch_candidate
+        else
+          "heads/#{branch_candidate}"
+        end
+      end
+
+      def tx_resource
+        @tx_resource ||= if process_all_branches?
+          resource = project.api.get_resource(project.name, resource_slug)
+          categories = deserialize_categories(Array(resource['categories']))
+          project.resource(resource_slug, categories['branch'])
+        else
+          project.resource(resource_slug)
+        end
+      end
+
+      def process_all_branches?
+        repo.branch == 'all'
+      end
     end
   end
 end

--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -4,8 +4,6 @@ require 'json'
 require 'set'
 
 module Txgh
-  class TransifexApiError < StandardError; end
-
   class TransifexApi
     API_ROOT = '/api/2'
 
@@ -39,7 +37,7 @@ module Txgh
 
     def create_or_update(tx_resource, content, categories = [])
       if resource_exists?(tx_resource)
-        resource = get_resource(tx_resource)
+        resource = get_resource(*tx_resource.slugs)
         new_categories = Set.new(resource['categories'])
         new_categories.merge(categories)
 
@@ -56,7 +54,7 @@ module Txgh
         slug: tx_resource.resource_slug,
         name: tx_resource.source_file,
         i18n_type: tx_resource.type,
-        categories: categories.uniq,
+        categories: CategorySupport.join_categories(categories.uniq),
         content: get_content_io(tx_resource, content)
       }
 
@@ -99,8 +97,8 @@ module Txgh
       json_data['content']
     end
 
-    def get_resource(tx_resource)
-      url = "#{API_ROOT}/project/#{tx_resource.project_slug}/resource/#{tx_resource.resource_slug}/"
+    def get_resource(project_slug, resource_slug)
+      url = "#{API_ROOT}/project/#{project_slug}/resource/#{resource_slug}/"
       response = connection.get(url)
       raise_error!(response)
       JSON.parse(response.body)

--- a/lib/txgh/transifex_project.rb
+++ b/lib/txgh/transifex_project.rb
@@ -12,9 +12,13 @@ module Txgh
       config['name']
     end
 
-    def resource(slug)
-      tx_config.resources.find do |resource|
-        resource.resource_slug == slug
+    def resource(slug, branch = nil)
+      if branch
+        TxBranchResource.find(self, slug, branch)
+      else
+        tx_config.resources.find do |resource|
+          resource.resource_slug == slug
+        end
       end
     end
 

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -5,8 +5,8 @@ module Txgh
     extend Forwardable
 
     def_delegators :@resource, *[
-      :project_slug, :resource_slug, :type, :source_lang,
-      :source_file, :translation_file, :lang_map, :translation_path
+      :project_slug, :resource_slug, :type, :source_lang, :source_file,
+      :translation_file, :lang_map, :translation_path, :slugs
     ]
 
     attr_reader :resource, :branch

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -17,7 +17,10 @@ module Txgh
 
         if resource_slug.end_with?(suffix)
           resource_slug = resource_slug.chomp(suffix)
-          new(project.resource(resource_slug), branch)
+
+          if resource = project.resource(resource_slug)
+            new(resource, branch)
+          end
         end
       end
     end

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -1,0 +1,40 @@
+require 'forwardable'
+
+module Txgh
+  class TxBranchResource
+    extend Forwardable
+
+    def_delegators :@resource, *[
+      :project_slug, :resource_slug, :type, :source_lang,
+      :source_file, :translation_file, :lang_map, :translation_path
+    ]
+
+    attr_reader :resource, :branch
+
+    class << self
+      def find(project, resource_slug, branch)
+        suffix = "-#{Utils.slugify(branch)}"
+
+        if resource_slug.end_with?(suffix)
+          resource_slug = resource_slug.chomp(suffix)
+          new(project.resource(resource_slug), branch)
+        end
+      end
+    end
+
+    def initialize(resource, branch)
+      @resource = resource
+      @branch = branch
+    end
+
+    def resource_slug
+      "#{resource.resource_slug}-#{slugified_branch}"
+    end
+
+    private
+
+    def slugified_branch
+      Utils.slugify(branch)
+    end
+  end
+end

--- a/lib/txgh/tx_resource.rb
+++ b/lib/txgh/tx_resource.rb
@@ -36,5 +36,9 @@ module Txgh
     def translation_path(language)
       translation_file.gsub('<lang>', language)
     end
+
+    def slugs
+      [project_slug, resource_slug]
+    end
   end
 end

--- a/lib/txgh/utils.rb
+++ b/lib/txgh/utils.rb
@@ -1,0 +1,9 @@
+module Txgh
+  module Utils
+    def slugify(str)
+      str.gsub('/', '_')
+    end
+  end
+
+  Utils.extend(Utils)
+end

--- a/spec/category_support_spec.rb
+++ b/spec/category_support_spec.rb
@@ -9,6 +9,12 @@ describe CategorySupport do
       result = CategorySupport.deserialize_categories(categories)
       expect(result).to eq('captain' => 'janeway', 'commander' => 'chakotay')
     end
+
+    it 'converts an array of space-separated categories' do
+      categories = ['captain:janeway commander:chakotay']
+      result = CategorySupport.deserialize_categories(categories)
+      expect(result).to eq('captain' => 'janeway', 'commander' => 'chakotay')
+    end
   end
 
   describe '.serialize_categories' do

--- a/spec/category_support_spec.rb
+++ b/spec/category_support_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+include Txgh
+
+describe CategorySupport do
+  describe '.deserialize_categories' do
+    it 'converts an array of categories into a hash' do
+      categories = %w(captain:janeway commander:chakotay)
+      result = CategorySupport.deserialize_categories(categories)
+      expect(result).to eq('captain' => 'janeway', 'commander' => 'chakotay')
+    end
+  end
+
+  describe '.serialize_categories' do
+    it 'converts a hash of categories into an array' do
+      categories = { 'captain' => 'janeway', 'commander' => 'chakotay' }
+      result = CategorySupport.serialize_categories(categories)
+      expect(result.sort).to eq(['captain:janeway', 'commander:chakotay'])
+    end
+  end
+
+  describe '.escape_category' do
+    it 'replaces spaces in category values' do
+      expect(CategorySupport.escape_category('Katherine Janeway')).to(
+        eq('Katherine_Janeway')
+      )
+    end
+  end
+
+  describe '.join_categories' do
+    it 'joins an array of categories by spaces' do
+      expect(CategorySupport.join_categories(%w(foo:bar baz:boo))).to(
+        eq('foo:bar baz:boo')
+      )
+    end
+  end
+end

--- a/spec/handlers/transifex_hook_handler_spec.rb
+++ b/spec/handlers/transifex_hook_handler_spec.rb
@@ -7,11 +7,15 @@ include Txgh::Handlers
 describe TransifexHookHandler do
   include StandardTxghSetup
 
+  let(:requested_resource_slug) do
+    resource_slug
+  end
+
   let(:handler) do
     TransifexHookHandler.new(
       project: transifex_project,
       repo: github_repo,
-      resource_slug: resource_slug,
+      resource_slug: requested_resource_slug,
       language: language,
       logger: logger
     )
@@ -20,7 +24,7 @@ describe TransifexHookHandler do
   before(:each) do
     expect(transifex_api).to(receive(:download)) do |resource, language|
       expect(resource.project_slug).to eq(project_name)
-      expect(resource.resource_slug).to eq(resource_slug)
+      expect(resource.resource_slug).to eq(requested_resource_slug)
       translations
     end
   end
@@ -33,6 +37,29 @@ describe TransifexHookHandler do
     )
 
     handler.execute
+  end
+
+  context 'when asked to process all branches' do
+    let(:branch) { 'all' }
+    let(:ref) { 'heads/my_branch' }
+
+    let(:requested_resource_slug) do
+      'my_resource-heads_my_branch'
+    end
+
+    it 'pushes to the individual branch' do
+      expect(transifex_api).to receive(:get_resource) do
+        { 'categories' => ["branch:#{ref}"] }
+      end
+
+      expect(github_api).to(
+        receive(:commit).with(
+          repo_name, ref, "translations/#{language}/sample.po", translations
+        )
+      )
+
+      handler.execute
+    end
   end
 
   context 'with a tag instead of a branch' do

--- a/spec/handlers/transifex_hook_handler_spec.rb
+++ b/spec/handlers/transifex_hook_handler_spec.rb
@@ -11,7 +11,7 @@ describe TransifexHookHandler do
     TransifexHookHandler.new(
       project: transifex_project,
       repo: github_repo,
-      resource: resource_slug,
+      resource_slug: resource_slug,
       language: language,
       logger: logger
     )

--- a/spec/integration/cassettes/github_l10n_hook_endpoint.yml
+++ b/spec/integration/cassettes/github_l10n_hook_endpoint.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:16 GMT
+      - Tue, 26 Jan 2016 16:58:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -35,9 +35,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4993'
+      - '4987'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -62,12 +62,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Github-Request-Id:
-      - 04358C36:175B1:7347075:56A67CF0
+      - A6F186B5:2071:3752D2B:56A7A5C2
     body:
       encoding: UTF-8
       string: '{"message":"Reference already exists","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:16 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:43 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed
@@ -93,7 +93,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:16 GMT
+      - Tue, 26 Jan 2016 16:58:43 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -103,9 +103,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4992'
+      - '4986'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -139,9 +139,9 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - bae57931a6fe678a3dffe9be8e7819c8
+      - d594a23ec74671eba905bf91ef329026
       X-Github-Request-Id:
-      - 04358C36:175AD:1FDCFD6:56A67CF0
+      - A6F186B5:2075:9DF5EBC:56A7A5C3
     body:
       encoding: UTF-8
       string: '{"sha":"6eebc3eee49e8d46f6dbec16fe3360961bfdd8ed","commit":{"author":{"name":"Matthew
@@ -150,7 +150,7 @@ http_interactions:
         -34,3 +34,5 @@ msgid \"Eight\"\n msgstr \"Eight\"\n msgid \"Nine\"\n msgstr
         \"Nine\"\n+msgid \"Ten\"\n+msgstr \"Ten\""}]}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:17 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:44 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50?recursive=1
@@ -176,7 +176,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:17 GMT
+      - Tue, 26 Jan 2016 16:58:44 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -186,9 +186,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4991'
+      - '4985'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
@@ -222,14 +222,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 318e55760cf7cdb40e61175a4d36cd32
+      - e183f7c661b1bbc2c987b3c4dc7b04e0
       X-Github-Request-Id:
-      - 04358C36:175B3:580AC5B:56A67CF0
+      - A6F186B5:2075:9DF5FB3:56A7A5C3
     body:
       encoding: UTF-8
       string: '{"sha":"572b0507c4109703788333808a0b0019c0000f50","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/572b0507c4109703788333808a0b0019c0000f50","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/5b5d383f4f107ff4d53c8fa4ce1166b63d1a4458"},{"path":"translations/el_GR","mode":"040000","type":"tree","sha":"396520f008766ce17de7b254cdfd3d7b4eda6b44","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/396520f008766ce17de7b254cdfd3d7b4eda6b44"},{"path":"translations/el_GR/sample.po","mode":"100644","type":"blob","sha":"98f5f909182137fd6416b4e672a85c013fef7a3a","size":1181,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/98f5f909182137fd6416b4e672a85c013fef7a3a"},{"path":"translations/el_GR/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"},{"path":"translations/test.txt","mode":"100644","type":"blob","sha":"f16628a67170414c9d346279f2595e77a1c3cf0f","size":28,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/f16628a67170414c9d346279f2595e77a1c3cf0f"}],"truncated":false}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:17 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:45 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6
@@ -255,7 +255,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:17 GMT
+      - Tue, 26 Jan 2016 16:58:44 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -265,9 +265,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4990'
+      - '4984'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -299,14 +299,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 474556b853193c38f1b14328ce2d1b7d
+      - dc1ce2bfb41810a06c705e83b388572d
       X-Github-Request-Id:
-      - 04358C36:175AF:410AFDB:56A67CF1
+      - A6F186B5:2072:4E8154E:56A7A5C4
     body:
       encoding: UTF-8
       string: '{"sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6","content":"IyBUcmFuc2xhdGlvbiBmaWxlIGZvciBUcmFuc2lmZXguCiMgQ29weXJpZ2h0\nIChDKSAyMDA3LTIwMTAgSW5kaWZleCBMdGQuCiMgVGhpcyBmaWxlIGlzIGRp\nc3RyaWJ1dGVkIHVuZGVyIHRoZSBzYW1lIGxpY2Vuc2UgYXMgdGhlIFRyYW5z\naWZleCBwYWNrYWdlLgojCiMgVHJhbnNsYXRvcnM6Cm1zZ2lkICIiCm1zZ3N0\nciAiIgoiUHJvamVjdC1JZC1WZXJzaW9uOiBUcmFuc2lmZXhcbiIKIlJlcG9y\ndC1Nc2dpZC1CdWdzLVRvOiBcbiIKIlBPVC1DcmVhdGlvbi1EYXRlOiAyMDE1\nLTAyLTE3IDIwOjEwKzAwMDBcbiIKIlBPLVJldmlzaW9uLURhdGU6IDIwMTMt\nMTAtMjIgMTA6NTcrMDAwMFxuIgoiTGFzdC1UcmFuc2xhdG9yOiBJbGlhcy1E\naW1pdHJpb3MgVnJhY2huaXNcbiIKIkxhbmd1YWdlLVRlYW06IExBTkdVQUdF\nIDxMTEBsaS5vcmc+XG4iCiJMYW5ndWFnZTogZW5cbiIKIk1JTUUtVmVyc2lv\nbjogMS4wXG4iCiJDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9\nVVRGLThcbiIKIkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IDhiaXRcbiIK\nIlBsdXJhbC1Gb3JtczogbnBsdXJhbHM9MjsgcGx1cmFsPShuICE9IDEpO1xu\nIgptc2dpZCAiT25lIgptc2dzdHIgIk9uZSIKbXNnaWQgIlR3byIKbXNnc3Ry\nICJUd28iCm1zZ2lkICJUaHJlZSIKbXNnc3RyICJUaHJlZSIKbXNnaWQgIkZv\ndXIiCm1zZ3N0ciAiRm91ciIKbXNnaWQgIkZpdmUiCm1zZ3N0ciAiRml2ZSIK\nbXNnaWQgIlNpeCIKbXNnc3RyICJTaXgiCm1zZ2lkICJTZXZlbiIKbXNnc3Ry\nICJTZXZlbiIKbXNnaWQgIkVpZ2h0Igptc2dzdHIgIkVpZ2h0Igptc2dpZCAi\nTmluZSIKbXNnc3RyICJOaW5lIgptc2dpZCAiVGVuIgptc2dzdHIgIlRlbiIK\n","encoding":"base64"}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:18 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:46 GMT
 - request:
     method: get
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
@@ -335,9 +335,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:45 GMT
       Expires:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:45 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -347,18 +347,19 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
+      - X-Mapping-fjhppofk=B8558B7BB369B761FC4CE03884ACF0F5; path=/
       Last-Modified:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:45 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: "{\n    \"source_language_code\": \"en\", \n    \"name\": \"sample.po\",
         \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
-        \n    \"categories\": []\n}"
+        \n    \"categories\": [\n        \"branch:refs/tags/L10N\", \n        \"author:Txgh
+        Bot\"\n    ]\n}"
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:18 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:46 GMT
 - request:
     method: get
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
@@ -387,9 +388,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:46 GMT
       Expires:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:46 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -399,24 +400,25 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
+      - X-Mapping-fjhppofk=D7F0B90A7FEFB2573FEF4C177EEBE6A8; path=/
       Last-Modified:
-      - Mon, 25 Jan 2016 19:52:18 GMT
+      - Tue, 26 Jan 2016 16:58:46 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: "{\n    \"source_language_code\": \"en\", \n    \"name\": \"sample.po\",
         \n    \"i18n_type\": \"PO\", \n    \"priority\": \"0\", \n    \"slug\": \"samplepo\",
-        \n    \"categories\": []\n}"
+        \n    \"categories\": [\n        \"branch:refs/tags/L10N\", \n        \"author:Txgh
+        Bot\"\n    ]\n}"
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:19 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:47 GMT
 - request:
     method: put
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/
     body:
       encoding: UTF-8
-      string: '{"categories":[]}'
+      string: '{"categories":["branch:refs/tags/L10N","author:Txgh Bot"]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -441,9 +443,9 @@ http_interactions:
       Content-Type:
       - text/plain
       Date:
-      - Mon, 25 Jan 2016 19:52:19 GMT
+      - Tue, 26 Jan 2016 16:58:47 GMT
       Expires:
-      - Mon, 25 Jan 2016 19:52:19 GMT
+      - Tue, 26 Jan 2016 16:58:47 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -453,16 +455,16 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=7BA9C65DD9CD0F1A96194A82BFB61D00; path=/
+      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
       Last-Modified:
-      - Mon, 25 Jan 2016 19:52:19 GMT
+      - Tue, 26 Jan 2016 16:58:47 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: OK
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:20 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:48 GMT
 - request:
     method: put
     uri: https://txgh.bot:<TRANSIFEX_PASSWORD>@www.transifex.com/api/2/project/test-project-88/resource/samplepo/content/
@@ -508,9 +510,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 25 Jan 2016 19:52:20 GMT
+      - Tue, 26 Jan 2016 16:58:48 GMT
       Expires:
-      - Mon, 25 Jan 2016 19:52:20 GMT
+      - Tue, 26 Jan 2016 16:58:48 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -520,9 +522,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=C7ADAD16FC9FAF25B589211B926C5FF5; path=/
+      - X-Mapping-fjhppofk=7BA9C65DD9CD0F1A96194A82BFB61D00; path=/
       Last-Modified:
-      - Mon, 25 Jan 2016 19:52:20 GMT
+      - Tue, 26 Jan 2016 16:58:48 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -530,5 +532,5 @@ http_interactions:
       string: "{\n    \"strings_added\": 0, \n    \"strings_updated\": 0, \n    \"strings_delete\":
         0, \n    \"redirect\": \"/txgh-test/test-project-88/samplepo/\"\n}"
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:20 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:49 GMT
 recorded_with: VCR 3.0.1

--- a/spec/integration/cassettes/transifex_hook_endpoint.yml
+++ b/spec/integration/cassettes/transifex_hook_endpoint.yml
@@ -28,9 +28,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 25 Jan 2016 19:52:12 GMT
+      - Tue, 26 Jan 2016 16:58:37 GMT
       Expires:
-      - Mon, 25 Jan 2016 19:52:12 GMT
+      - Tue, 26 Jan 2016 16:58:37 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -40,9 +40,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - X-Mapping-fjhppofk=D7F0B90A7FEFB2573FEF4C177EEBE6A8; path=/
+      - X-Mapping-fjhppofk=EC88B8A0F350FE88E4BF67A3F4B1C219; path=/
       Last-Modified:
-      - Mon, 25 Jan 2016 19:52:12 GMT
+      - Tue, 26 Jan 2016 16:58:37 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -63,7 +63,7 @@ http_interactions:
         \\\"Eight\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid \\\"Nine\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid
         \\\"Ten\\\"\\nmsgstr \\\"\\\"\\n\", \n    \"mimetype\": \"text/x-po\"\n}"
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:12 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:39 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs
@@ -101,7 +101,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:12 GMT
+      - Tue, 26 Jan 2016 16:58:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -111,9 +111,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4999'
+      - '4993'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -147,14 +147,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 173530fed4bbeb1e264b2ed22e8b5c20
+      - 01d096e6cfe28f8aea352e988c332cd3
       X-Github-Request-Id:
-      - 04358C36:175B0:5A724C7:56A67CEC
+      - A6F186B5:2075:9DF583B:56A7A5BE
     body:
       encoding: UTF-8
       string: '{"sha":"540a3d944ac19f573e756de687c8c4f3f9847b53","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/540a3d944ac19f573e756de687c8c4f3f9847b53"}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:14 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:40 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
@@ -180,7 +180,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:14 GMT
+      - Tue, 26 Jan 2016 16:58:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -190,15 +190,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4998'
+      - '4992'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
       - Mon, 11 Jan 2016 23:45:43 GMT
       Etag:
-      - W/"2b6917f18180a72bbe11323d56090489"
+      - W/"829c010dd79e2ffb3e86de693245e41f"
       X-Poll-Interval:
       - '300'
       X-Oauth-Scopes:
@@ -228,17 +228,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - d594a23ec74671eba905bf91ef329026
+      - 173530fed4bbeb1e264b2ed22e8b5c20
       X-Github-Request-Id:
-      - 04358C36:175AB:FE5639:56A67CEE
+      - A6F186B5:2073:6B5EDAB:56A7A5BF
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"6ea48545155f561b142e730f7284961b312090fc","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"51886fe773848ff49f5313c8afe4e026f044ae66","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/51886fe773848ff49f5313c8afe4e026f044ae66"}}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:14 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:40 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/51886fe773848ff49f5313c8afe4e026f044ae66
     body:
       encoding: US-ASCII
       string: ''
@@ -261,7 +261,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:14 GMT
+      - Tue, 26 Jan 2016 16:58:40 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -271,15 +271,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4997'
+      - '4991'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Last-Modified:
-      - Sat, 23 Jan 2016 01:12:19 GMT
+      - Mon, 25 Jan 2016 22:14:05 GMT
       Etag:
-      - W/"ab77d4b0a5e9d218c6cb2b4cde3b771b"
+      - W/"4b78669c490ba191aff076a1e68dad2d"
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -307,15 +307,15 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 139317cebd6caf9cd03889139437f00b
+      - a6882e5cd2513376cb9481dbcd83f3a2
       X-Github-Request-Id:
-      - 04358C36:175B1:7346E44:56A67CEE
+      - A6F186B5:2075:9DF5A2A:56A7A5BF
     body:
       encoding: UTF-8
-      string: '{"sha":"6ea48545155f561b142e730f7284961b312090fc","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-23T01:12:19Z"},"message":"Updating
-        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/6ea48545155f561b142e730f7284961b312090fc/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"0ed84551e879a3fe3181bb758b08f792ebec4769","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/0ed84551e879a3fe3181bb758b08f792ebec4769","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/0ed84551e879a3fe3181bb758b08f792ebec4769"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
+      string: '{"sha":"51886fe773848ff49f5313c8afe4e026f044ae66","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T22:14:05Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T22:14:05Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/51886fe773848ff49f5313c8afe4e026f044ae66","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/51886fe773848ff49f5313c8afe4e026f044ae66","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/51886fe773848ff49f5313c8afe4e026f044ae66","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/51886fe773848ff49f5313c8afe4e026f044ae66/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"5a92eb64ba0f092fccb9942ea8763bdba385694f","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/5a92eb64ba0f092fccb9942ea8763bdba385694f","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/5a92eb64ba0f092fccb9942ea8763bdba385694f"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:41 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees
@@ -341,7 +341,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:15 GMT
+      - Tue, 26 Jan 2016 16:58:40 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -351,9 +351,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4996'
+      - '4990'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
@@ -387,20 +387,20 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - c6c65e5196703428e7641f7d1e9bc353
+      - 01d096e6cfe28f8aea352e988c332cd3
       X-Github-Request-Id:
-      - 04358C36:175B3:580AABD:56A67CEE
+      - A6F186B5:2074:8893062:56A7A5C0
     body:
       encoding: UTF-8
       string: '{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"64881902c6515e26c22e022abc0bedeaa15eafdc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/64881902c6515e26c22e022abc0bedeaa15eafdc"}],"truncated":false}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:41 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits
     body:
       encoding: UTF-8
-      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["6ea48545155f561b142e730f7284961b312090fc"]}'
+      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["51886fe773848ff49f5313c8afe4e026f044ae66"]}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -420,7 +420,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:15 GMT
+      - Tue, 26 Jan 2016 16:58:41 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -430,19 +430,19 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4995'
+      - '4989'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
-      - '"23db945e0f6a850200970c3b09c4376d"'
+      - '"fd8f1f505d5262148b82200a46d27bd5"'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1
+      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f0356f2c6216af45b74a517835a6b8d11c246a33
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       - Accept-Encoding
@@ -466,21 +466,21 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 593010132f82159af0ded24b4932e109
+      - 4c8b2d4732c413f4b9aefe394bd65569
       X-Github-Request-Id:
-      - 04358C36:175AE:2DEA956:56A67CEF
+      - A6F186B5:2074:889311A:56A7A5C1
     body:
       encoding: UTF-8
-      string: '{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/dd6f7c2301400a36475306556d7da1e56b7477e1","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T19:52:15Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-25T19:52:15Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
-        translations for translations/el_GR/sample.po","parents":[{"sha":"6ea48545155f561b142e730f7284961b312090fc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/6ea48545155f561b142e730f7284961b312090fc","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/6ea48545155f561b142e730f7284961b312090fc"}]}'
+      string: '{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f0356f2c6216af45b74a517835a6b8d11c246a33","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f0356f2c6216af45b74a517835a6b8d11c246a33","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-26T16:58:41Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-01-26T16:58:41Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
+        translations for translations/el_GR/sample.po","parents":[{"sha":"51886fe773848ff49f5313c8afe4e026f044ae66","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/51886fe773848ff49f5313c8afe4e026f044ae66","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/51886fe773848ff49f5313c8afe4e026f044ae66"}]}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:15 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:42 GMT
 - request:
     method: patch
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
     body:
       encoding: UTF-8
-      string: '{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","force":true}'
+      string: '{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","force":true}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -500,7 +500,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 25 Jan 2016 19:52:15 GMT
+      - Tue, 26 Jan 2016 16:58:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -510,13 +510,13 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4994'
+      - '4988'
       X-Ratelimit-Reset:
-      - '1453755132'
+      - '1453830860'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Etag:
-      - W/"38da3d7f7e3ba497adac4b879211dae1"
+      - W/"a660aabe64518dee2922fd0ed8b92530"
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
@@ -544,12 +544,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 7b641bda7ec2ca7cd9df72d2578baf75
+      - a30e6f9aa7cf5731b87dfb3b9992202d
       X-Github-Request-Id:
-      - 04358C36:175B2:841DADB:56A67CEF
+      - A6F186B5:2075:9DF5CDD:56A7A5C1
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"dd6f7c2301400a36475306556d7da1e56b7477e1","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/dd6f7c2301400a36475306556d7da1e56b7477e1"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f0356f2c6216af45b74a517835a6b8d11c246a33"}}'
     http_version: 
-  recorded_at: Mon, 25 Jan 2016 19:52:16 GMT
+  recorded_at: Tue, 26 Jan 2016 16:58:43 GMT
 recorded_with: VCR 3.0.1

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -77,17 +77,17 @@ describe TransifexApi do
         )
 
         expect(payload[:content].io.string).to eq('new_content')
-        expect(payload[:categories]).to eq(['abc'])
+        expect(payload[:categories]).to eq('abc def')
         response
       end
 
       expect(response).to receive(:status).and_return(200)
-      api.create(resource, 'new_content', ['abc'])
+      api.create(resource, 'new_content', ['abc', 'def'])
     end
 
     it 'submits de-duped categories' do
       expect(connection).to receive(:post) do |url, payload|
-        expect(payload[:categories]).to eq(['abc'])
+        expect(payload[:categories]).to eq('abc')
         response
       end
 
@@ -221,14 +221,14 @@ describe TransifexApi do
 
       expect(response).to receive(:status).and_return(200)
       expect(response).to receive(:body).and_return('{"foo":"bar"}')
-      expect(api.get_resource(resource)).to eq({ 'foo' => 'bar' })
+      expect(api.get_resource(*resource.slugs)).to eq({ 'foo' => 'bar' })
     end
 
     it 'raises an exception if the api responds with an error code' do
       allow(connection).to receive(:get).and_return(response)
       allow(response).to receive(:status).and_return(404)
       allow(response).to receive(:body).and_return('{}')
-      expect { api.get_resource(resource) }.to raise_error(TransifexApiError)
+      expect { api.get_resource(*resource.slugs) }.to raise_error(TransifexApiError)
     end
   end
 end

--- a/spec/tx_branch_resource_spec.rb
+++ b/spec/tx_branch_resource_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+include Txgh
+
+describe TxBranchResource do
+  let(:resource_slug) { 'resource_slug' }
+  let(:resource_slug_with_branch) { "#{resource_slug}-heads_my_branch" }
+  let(:project_slug) { 'project_slug' }
+  let(:branch) { 'heads/my_branch' }
+
+  let(:api) { :api }
+  let(:config) { { name: project_slug } }
+  let(:resources) { [base_resource] }
+
+  let(:tx_config) do
+    TxConfig.new(resources, {})
+  end
+
+  let(:project) do
+    TransifexProject.new(config, tx_config, api)
+  end
+
+  let(:base_resource) do
+    TxResource.new(
+      project_slug, resource_slug, 'type', 'source_lang', 'source_file',
+      'ko-KR:ko', 'translation_file'
+    )
+  end
+
+  describe '.find' do
+    it 'finds the correct resource' do
+      resource = TxBranchResource.find(project, resource_slug_with_branch, branch)
+      expect(resource).to be_a(TxBranchResource)
+      expect(resource.resource).to eq(base_resource)
+      expect(resource.branch).to eq(branch)
+    end
+
+    it 'returns nil if no resource matches' do
+      resource = TxBranchResource.find(project, 'foobar', branch)
+      expect(resource).to be_nil
+
+      resource = TxBranchResource.find(project, resource_slug_with_branch, 'foobar')
+      expect(resource).to be_nil
+    end
+  end
+
+  context 'with a resource' do
+    let(:resource) do
+      TxBranchResource.new(base_resource, branch)
+    end
+
+    describe '#resource_slug' do
+      it 'adds the branch name to the resource slug' do
+        expect(resource.resource.resource_slug).to eq(resource_slug)
+        expect(resource.resource_slug).to eq(resource_slug_with_branch)
+      end
+    end
+  end
+end

--- a/spec/tx_resource_spec.rb
+++ b/spec/tx_resource_spec.rb
@@ -25,4 +25,10 @@ describe TxResource do
       expect(resource.lang_map('foo')).to eq('foo')
     end
   end
+
+  describe '#slugs' do
+    it 'returns an array containing the project and resource slugs' do
+      expect(resource.slugs).to eq(%w(project_slug resource_slug))
+    end
+  end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+include Txgh
+
+describe Utils do
+  describe '.slugify' do
+    it 'correctly slugifies a string with slashes' do
+      expect(Utils.slugify('abc/def/ghi')).to eq('abc_def_ghi')
+    end
+
+    it 'does not replace underscores' do
+      expect(Utils.slugify('abc_def/ghi')).to eq('abc_def_ghi')
+    end
+  end
+end


### PR DESCRIPTION
This is an opt-in feature. Normally txgh pushes and pulls from a single branch, specified in the configuration. By specifying the special keyword `'all'` instead of a branch name, txgh will now process commits and upload resources for individual git branches. It does this by tagging each resource with the corresponding branch name using Transifex's categories feature. Each uploaded resource will have two categories, `branch:branch_name` and `author:First_Last`. Txgh uses the branch category to identify which git branch to push the finished translations to upon receiving a Transifex webhook request.

@jdoconnor @st33b @zvkemp