### PR TITLE
Tx signature v2

### DIFF
--- a/lib/txgh/transifex_request_auth.rb
+++ b/lib/txgh/transifex_request_auth.rb
@@ -27,7 +27,7 @@ module Txgh
         actual_signature_v1 == expected_signature_v1 or actual_signature_v2 == expected_signature_v2
       end
 
-      def header_value_v1(params, is_json)
+      def header_value_v1(params, secret)
         digest(HMAC_DIGEST, secret, transform(params))
       end
 

--- a/lib/txgh/transifex_request_auth.rb
+++ b/lib/txgh/transifex_request_auth.rb
@@ -10,31 +10,29 @@ module Txgh
 
     class << self
       def authentic_request?(request, secret)
-        expected_signature_v1 = header_value_v1(request, secret)
-        expected_signature_v2 = header_value_v2(request, secret)
-        actual_signature_v1 = request.env[RACK_HEADER]
-        actual_signature_v2 = request.env[RACK_HEADER_V2]
-        actual_signature_v1 == expected_signature_v1 or actual_signature_v2 == expected_signature_v2
-      end
-
-      def header_value_v1(request, secret)
-        request.body.rewind
-        content = request.body.read
-        if request.env['CONTENT_TYPE'] == "application/json"
-          params = JSON.parse(content)
-        else
-          params = URI.decode_www_form(content)
-        end
-        digest(HMAC_DIGEST, secret, transform(params))
-      end
-
-      def header_value_v2(request, secret)
         request.body.rewind
         content = request.body.read
         http_verb = request.request_method
         url = request.url
         date = request.env['HTTP_DATE']
-        content_md5 = request.env['HTTP_CONTENT_MD5']
+        if request.env['CONTENT_TYPE'] == "application/json"
+          params = JSON.parse(content)
+        else
+          params = URI.decode_www_form(content)
+        end
+        expected_signature_v1 = header_value_v1(params, secret)
+        expected_signature_v2 = header_value_v2(http_verb, url, date, content, secret)
+        actual_signature_v1 = request.env[RACK_HEADER]
+        actual_signature_v2 = request.env[RACK_HEADER_V2]
+        actual_signature_v1 == expected_signature_v1 or actual_signature_v2 == expected_signature_v2
+      end
+
+      def header_value_v1(params, is_json)
+        digest(HMAC_DIGEST, secret, transform(params))
+      end
+
+      def header_value_v2(http_verb, url, date, content, secret)
+        content_md5 = Digest::MD5.hexdigest content
         data = [http_verb, url, date, content_md5].join("\n")
         digest(HMAC_DIGEST_256, secret, data)
       end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -54,7 +54,7 @@ describe 'integration tests', integration: true do
     params = URI.decode_www_form(body)
     header(
       TransifexRequestAuth::TRANSIFEX_HEADER,
-      TransifexRequestAuth.header_value(params, config.transifex_project.webhook_secret)
+      TransifexRequestAuth.header_value_v1(params, config.transifex_project.webhook_secret)
     )
   end
 

--- a/spec/transifex_request_auth_spec.rb
+++ b/spec/transifex_request_auth_spec.rb
@@ -5,14 +5,19 @@ include Txgh
 
 describe TransifexRequestAuth do
   let(:secret) { 'abc123' }
-  let(:params) { 'param1=value1&param2=value2&param3=123' }
-  let(:valid_signature) { 'pXucIcivBezpfNgCGTHKYeDve84=' }
+  let(:formdata_params) { 'param1=value1&param2=value2&param3=123' }
+  let(:json_params) { '{"param1": "value1", "param2": "value2", "param3": 123}' }
+  let(:valid_signature_v1) { 'pXucIcivBezpfNgCGTHKYeDve84=' }
+  let(:valid_signature_v2) { '6zZG2fkHKFlNTSmckWDa+wUEyhQkPAbhaTxjMiJf23c=' }
+  let(:date) { 'Fri, 17 Feb 2017 08:24:07 GMT' }
+  let(:http_verb) { 'POST' }
+  let(:url) { 'http://www.transifex.com/' }
 
   describe '.authentic_request?' do
     it 'returns true if the request is signed correctly' do
       request = Rack::Request.new(
-        TransifexRequestAuth::RACK_HEADER => valid_signature,
-        'rack.input' => StringIO.new(params)
+        TransifexRequestAuth::RACK_HEADER => valid_signature_v1,
+        'rack.input' => StringIO.new(formdata_params)
       )
 
       authentic = TransifexRequestAuth.authentic_request?(request, secret)
@@ -22,7 +27,7 @@ describe TransifexRequestAuth do
     it 'returns false if the request is not signed correctly' do
       request = Rack::Request.new(
         TransifexRequestAuth::RACK_HEADER => 'incorrect',
-        'rack.input' => StringIO.new(params)
+        'rack.input' => StringIO.new(formdata_params)
       )
 
       authentic = TransifexRequestAuth.authentic_request?(request, secret)
@@ -31,9 +36,15 @@ describe TransifexRequestAuth do
   end
 
   describe '.header' do
-    it 'calculates the signature and formats it as an http header' do
-      value = TransifexRequestAuth.header_value_v1(params, secret)
-      expect(value).to eq(valid_signature)
+    it 'calculates the V1 signature and formats it as an http header' do
+      value = TransifexRequestAuth.header_value_v1(formdata_params, secret)
+      expect(value).to eq(valid_signature_v1)
+    end
+
+    it 'calculates the V2 signature and formats it as an http header' do
+      url = 'http://www.transifex.com/'
+      value = TransifexRequestAuth.header_value_v2(http_verb, url, date, json_params, secret)
+      expect(value).to eq(valid_signature_v2)
     end
   end
 end

--- a/spec/transifex_request_auth_spec.rb
+++ b/spec/transifex_request_auth_spec.rb
@@ -37,7 +37,8 @@ describe TransifexRequestAuth do
 
   describe '.header' do
     it 'calculates the V1 signature and formats it as an http header' do
-      value = TransifexRequestAuth.header_value_v1(formdata_params, secret)
+      params = {:param1 => 'value1', :param2 => 'value2', :param3 => 123}
+      value = TransifexRequestAuth.header_value_v1(params, secret)
       expect(value).to eq(valid_signature_v1)
     end
 

--- a/spec/transifex_request_auth_spec.rb
+++ b/spec/transifex_request_auth_spec.rb
@@ -32,8 +32,7 @@ describe TransifexRequestAuth do
 
   describe '.header' do
     it 'calculates the signature and formats it as an http header' do
-      params = {:param1 => 'value1', :param2 => 'value2', :param3 => 123}
-      value = TransifexRequestAuth.header_value(params, secret)
+      value = TransifexRequestAuth.header_value_v1(params, secret)
       expect(value).to eq(valid_signature)
     end
   end


### PR DESCRIPTION
Adds support for Transifex' V2 webhook signature while maintaining the previous behaviour for backwards compatibility.