### PR TITLE
Adding the Gemfile.lock to repository for docker image creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /config/secret/*
-Gemfile.lock
 *.rbc
 *.sassc
 .sass-cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,97 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    backports (3.11.3)
+    coderay (1.1.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    hashdiff (0.3.7)
+    json (2.1.0)
+    method_source (0.8.2)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    octokit (4.9.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    parseconfig (1.0.8)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
+    public_suffix (3.0.2)
+    puma (3.11.4)
+    rack (1.6.10)
+    rack-protection (1.5.5)
+      rack
+    rack-test (0.7.0)
+      rack (>= 1.0, < 3)
+    rake (12.3.1)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    safe_yaml (1.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    shotgun (0.9.2)
+      rack (>= 1.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    tilt (2.0.8)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  faraday
+  faraday_middleware
+  json
+  octokit
+  parseconfig
+  pry-nav
+  puma
+  rack
+  rack-test
+  rake
+  rspec
+  shotgun
+  sinatra
+  sinatra-contrib
+  vcr (~> 3.0.1)
+  webmock (~> 1.24.6)
+
+BUNDLED WITH
+   1.15.1


### PR DESCRIPTION
Other wise `docker build --no-cache -t txgh .` cause the following error:
```
Step 1/14 : FROM ruby:2.1-onbuild
# Executing 4 build triggers
COPY failed: stat /var/lib/docker/tmp/docker-builder622365825/Gemfile.lock: no such file or directory
```

This would enable to easily implement #64